### PR TITLE
Shutdown executor service when retrieving values

### DIFF
--- a/src/main/java/es/usc/citius/common/parallel/Parallel.java
+++ b/src/main/java/es/usc/citius/common/parallel/Parallel.java
@@ -163,8 +163,9 @@ public final class Parallel {
             Collection<V> results = new LinkedList<V>();
             for (Future<V> future : this.runningTasks) {
                 V result = future.get();
-                if (result != null) results.add(future.get());
+                if (result != null) results.add(result);
             }
+            this.executorService.shutdown();
             return results;
         }
     }


### PR DESCRIPTION
the executorService was not shutdown on ForEach.apply, leaving the threadpool open - a similar bug may exist in other entry points.
